### PR TITLE
make default for shouldSyncToRemoteService true

### DIFF
--- a/CGMBLEKit/TransmitterManagerState.swift
+++ b/CGMBLEKit/TransmitterManagerState.swift
@@ -26,7 +26,7 @@ public struct TransmitterManagerState: RawRepresentable, Equatable {
 
     public init(
         transmitterID: String,
-        shouldSyncToRemoteService: Bool = false,
+        shouldSyncToRemoteService: Bool = true,
         transmitterStartDate: Date? = nil,
         sensorStartOffset: UInt32? = nil
     ) {


### PR DESCRIPTION
The desired default setting for the Trio app is true (instead of false as used by LoopKit).