### PR TITLE
add ONE to display name

### DIFF
--- a/CGMBLEKitG6Plugin/Info.plist
+++ b/CGMBLEKitG6Plugin/Info.plist
@@ -23,7 +23,7 @@
 	<key>NSPrincipalClass</key>
 	<string>CGMBLEKitG6Plugin</string>
 	<key>com.loopkit.Loop.CGMManagerDisplayName</key>
-	<string>Dexcom G6</string>
+	<string>Dexcom G6 / ONE</string>
 	<key>com.loopkit.Loop.CGMManagerIdentifier</key>
 	<string>DexG6Transmitter</string>
 </dict>


### PR DESCRIPTION
Adds "ONE" to display name when selecting a CGM in Trio to address https://github.com/nightscout/Trio/issues/379

<img width="350" alt="cgms" src="https://github.com/user-attachments/assets/bc01b9b2-0355-43e8-9025-eb2844a259df">
