### PR TITLE
modify Dexcom upload default to true

### DIFF
--- a/CGMBLEKit/TransmitterManagerState.swift
+++ b/CGMBLEKit/TransmitterManagerState.swift
@@ -26,7 +26,7 @@ public struct TransmitterManagerState: RawRepresentable, Equatable {
 
     public init(
         transmitterID: String,
-        shouldSyncToRemoteService: Bool = false,
+        shouldSyncToRemoteService: Bool = true,
         transmitterStartDate: Date? = nil,
         sensorStartOffset: UInt32? = nil
     ) {


### PR DESCRIPTION
Update the `trio` branch to default of upload G5/G6 readings to be `true` instead of `false`